### PR TITLE
do not show useless and overloading infomation on the startpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,20 +107,6 @@
     <div class="container-fluid text-center label-warning" id="state">
       <h3 style="margin-bottom: 2px">Raumstatus</h3>
       <h4 style="margin-top:2px" id="stateText">Loading</h4>
-      <h5 class="margin"><a href="dashboard.html">Dashboard</a></h5>
-      <h5 class="margin"><a href="http://spaceapi-stats.n39.eu/#vspaceone">Statistiken</a></h5>
-      <div class="row">
-        <div class="col-sm-6">
-          <h4>Brücke</h4>
-          <div style="width:100%; margin-bottom:50px;" class="col-sm-6" id="Bruecke">
-          </div>
-        </div>
-        <div class="col-sm-6">
-          <h4>Maschinenraum</h4>
-          <div style="width:100%; margin-bottom:50px;" class="col-sm-6" id="Maschinenraum">
-          </div>
-        </div>
-      </div>
     </div>
 
     <div class="container-fluid bg-2 text-center">


### PR DESCRIPTION
What do you think about removing the temperature and humidity infomation from the index page? Is this information realy so important at this state?
